### PR TITLE
Added missing parameter in configuration : skin

### DIFF
--- a/ThePoser/ThePoser.php
+++ b/ThePoser/ThePoser.php
@@ -120,6 +120,7 @@ class ThePoserPlugin extends MantisPlugin {
     function config() {
         return array(
             'customLogo' => '',
+	    'skin' => 0,
 	    'headerHeight' => 0,// default=0, small=1, tiny=2
 	    'companyName' => 'setup you company name and logo',
 	    'companyUrl' => plugin_page('config'),


### PR DESCRIPTION
The parameter 'skin' was missing in config(). It triggered a warning when the plugin was just installed: "APPLICATION WARNING #100: Configuration option "plugin_ThePoser_skin" not found."
